### PR TITLE
Make depview rely on order

### DIFF
--- a/packages/dfgraph/src/dfgraph.ts
+++ b/packages/dfgraph/src/dfgraph.ts
@@ -129,7 +129,7 @@ class GraphManager {
       (cellid: any) => cellid.replace(/-/g, '').substr(0, 8) as string
     );
     this.minimap.updateOrder(modifiedorder);
-    this.depview.updateOrder(modifiedorder);
+    this.depview.updateOrder(modifiedorder,true);
     this.updateDepViews(true, true);
   };
 


### PR DESCRIPTION
This should fix #22 

This should make the depviewer smoother, minimap already relies on cell order. 

This makes the depviewer update based on the current cells in the notebook, this makes things like deletions immediately update the depviewer.