### PR TITLE
Fix cell toolbar display

### DIFF
--- a/packages/dfnotebook-extension/src/index.ts
+++ b/packages/dfnotebook-extension/src/index.ts
@@ -94,6 +94,8 @@ import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { IChangedArgs, PageConfig } from '@jupyterlab/coreutils';
 import { DataflowInputArea } from '@dfnotebook/dfcells';
 
+import { CellBarExtension } from '@jupyterlab/cell-toolbar';
+
 /**
  * The command IDs used by the notebook plugin.
  */
@@ -625,10 +627,42 @@ const MiniMap: JupyterFrontEndPlugin<void> = {
     };
 
 
+const cellToolbar: JupyterFrontEndPlugin<void> = {
+  id: '@dfnotebook/dfnotebook-extension:cell-toolbar',
+  description: 'Add the cells toolbar.',
+  autoStart: true,
+  activate: async (
+    app: JupyterFrontEnd,
+    settingRegistry: ISettingRegistry | null,
+    toolbarRegistry: IToolbarWidgetRegistry | null,
+    translator: ITranslator | null
+  ) => {
+    const toolbarItems =
+      settingRegistry && toolbarRegistry
+        ? createToolbarFactory(
+            toolbarRegistry,
+            settingRegistry,
+            CellBarExtension.FACTORY_NAME,
+            '@jupyterlab/cell-toolbar-extension:plugin',
+            translator ?? nullTranslator
+          )
+        : undefined;
+
+    // have to register this with our factory
+    app.docRegistry.addWidgetExtension(
+      DATAFLOW_FACTORY,
+      new CellBarExtension(app.commands, toolbarItems)
+    );
+  },
+  optional: [ISettingRegistry, IToolbarWidgetRegistry, ITranslator]
+};
+    
+
 const plugins: JupyterFrontEndPlugin<any>[] = [
   factory,
   widgetFactoryPlugin,
   trackerPlugin,
+  cellToolbar,
   DepViewer,
   MiniMap,
   GraphManagerPlugin

--- a/packages/dfnotebook-extension/style/index.css
+++ b/packages/dfnotebook-extension/style/index.css
@@ -4,6 +4,7 @@
 |----------------------------------------------------------------------------*/
 
 @import url('~@jupyterlab/notebook-extension/style/index.css');
+@import url('~@jupyterlab/cell-toolbar/style/index.css');
 @import url('~@dfnotebook/dfgraph/style/index.css');
 @import url('~@dfnotebook/dfnotebook/style/index.css');
 

--- a/packages/dfnotebook-extension/style/index.js
+++ b/packages/dfnotebook-extension/style/index.js
@@ -4,6 +4,7 @@
 |----------------------------------------------------------------------------*/
 
 import '@jupyterlab/notebook-extension/style/index.js';
+import '@jupyterlab/cell-toolbar/style/index.js';
 import '@dfnotebook/dfgraph/style/index.js';
 import '@dfnotebook/dfnotebook/style/index.js';
 


### PR DESCRIPTION
Fixes #31

There are two fixes: (1) add the cell-toolbar-extension plugin that links to the dataflow notebook widget factory, and (2) add the style for cell toolbar to the notebook-extension. The problem is precedence of the css rules as .jp-cell-toolbar rules were being overridden by .lm-widget