### PR TITLE
Fix the development install

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   },
   "scripts": {
     "build": "lerna run build",
-    "build:dev": "jlpm build & jlpm develop",
     "build:lib": "lerna run build:lib",
     "build:lib:prod": "lerna run build:lib:prod",
     "build:test": "lerna run build:test",
@@ -41,7 +40,7 @@
     "clean:slate": "python clean.py",
     "develop": "jupyter labextension develop --overwrite .",
     "install:extension": "lerna run install:extension",
-    "install:develop": "jlpm build && jlpm develop",
+    "install:develop": "jlpm install && jlpm build && jlpm develop",
     "lint": "jlpm && jlpm prettier && jlpm eslint && jlpm stylelint",
     "lint:check": "jlpm prettier:check && jlpm eslint:check && jlpm stylelint:check",
     "prettier": "prettier --write \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "scripts": {
     "build": "lerna run build",
+    "build:dev": "jlpm build & jlpm develop",
     "build:lib": "lerna run build:lib",
     "build:lib:prod": "lerna run build:lib:prod",
     "build:test": "lerna run build:test",
@@ -40,7 +41,7 @@
     "clean:slate": "python clean.py",
     "develop": "jupyter labextension develop --overwrite .",
     "install:extension": "lerna run install:extension",
-    "install:develop": "jlpm install && jlpm build && jlpm develop",
+    "install:develop": "jlpm build && jlpm develop",
     "lint": "jlpm && jlpm prettier && jlpm eslint && jlpm stylelint",
     "lint:check": "jlpm prettier:check && jlpm eslint:check && jlpm stylelint:check",
     "prettier": "prettier --write \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,9 +59,9 @@ build_cmd = "build:prod"
 npm = ["jlpm"]
 
 [tool.hatch.build.hooks.jupyter-builder.editable-build-kwargs]
-build_cmd = "install:extension"
+build_cmd = "build"
 npm = ["jlpm"]
-source_dir = "src"
+source_dir = "packages"
 build_dir = "dfnotebook/labextension"
 
 [tool.jupyter-releaser.options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ build_cmd = "build:prod"
 npm = ["jlpm"]
 
 [tool.hatch.build.hooks.jupyter-builder.editable-build-kwargs]
-build_cmd = "build"
+build_cmd = "build:dev"
 npm = ["jlpm"]
 source_dir = "packages"
 build_dir = "dfnotebook/labextension"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ build_cmd = "build:prod"
 npm = ["jlpm"]
 
 [tool.hatch.build.hooks.jupyter-builder.editable-build-kwargs]
-build_cmd = "build:dev"
+build_cmd = "build"
 npm = ["jlpm"]
 source_dir = "packages"
 build_dir = "dfnotebook/labextension"


### PR DESCRIPTION
Fixes #37

This fixes an issue with using `pip install -e .` directly to install a development version of dfnotebook-extension. Set the hatch builder to point to the packages directory as source_dir and use the standard build command