### PR TITLE
Draft PR: Changes related to metadata of a code cell, tags option and update of codecells based on exported variables 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,5 +135,6 @@ Untitled*.ipynb
 #Compiled files
 *.d.ts
 !packages/dfnotebook-extension/src/svg.d.ts
+!packages/dfnotebook/test/svg.d.ts
 packages/*/src/*.js
 packages/dfnotebook/fonts/*.*

--- a/.gitignore
+++ b/.gitignore
@@ -134,5 +134,6 @@ Untitled*.ipynb
 
 #Compiled files
 *.d.ts
+!packages/dfnotebook-extension/src/svg.d.ts
 packages/*/src/*.js
 packages/dfnotebook/fonts/*.*

--- a/packages/dfcells/src/inputarea.ts
+++ b/packages/dfcells/src/inputarea.ts
@@ -24,12 +24,15 @@ export class DataflowInputArea extends InputArea {
   }
 
   public addTag(value: string | null) {
-    this.model?.setMetadata('tag', value);
+    const dfmetadata = this.model?.getMetadata('dfmetadata');
+    dfmetadata.tag = value;
+    this.model?.setMetadata('dfmetadata', dfmetadata);
     this.prompt.updatePromptNode(this.prompt.executionCount);
   }
 
   public get tag(): string | null {
-    return this.model?.getMetadata('tag') || null;
+    const dfmetadata = this.model?.getMetadata('dfmetadata');
+    return dfmetadata?.tag;
   }
 }
 
@@ -51,8 +54,9 @@ export class DataflowInputPrompt extends InputPrompt {
   }
 
   public updatePromptNode(value: string | null) {
-    if (this.model?.getMetadata('tag')) {
-      this.node.textContent = `[${this.model.getMetadata('tag')}]:`;
+    const dfmetadata = this.model?.getMetadata('dfmetadata');
+    if (dfmetadata && dfmetadata.tag) {
+      this.node.textContent = `[${dfmetadata.tag}]:`;
     } else if (value === null) {
       this.node.textContent = ' ';
     } else {

--- a/packages/dfcells/src/widget.ts
+++ b/packages/dfcells/src/widget.ts
@@ -198,7 +198,6 @@ export class DataflowCodeCell extends CodeCell {
     setOutputArea(this);
     this.setPromptToId();
     this.addClass('df-cell');
-    setDFMetadata(this);
   }
 
   public setPromptToId() {
@@ -209,6 +208,8 @@ export class DataflowCodeCell extends CodeCell {
   initializeState(): this {
     super.initializeState();
     this.setPromptToId();
+    setDFMetadata(this);
+    this.model.contentChanged.connect(this._onContentChanged, this);
     return this;
   }
 
@@ -220,6 +221,17 @@ export class DataflowCodeCell extends CodeCell {
         break;
       default:
         break;
+    }
+  }
+
+  private _onContentChanged(): void {
+    let currentCode = this.model.sharedModel.getSource().trim();
+    let persistentCode = this.model.getMetadata('dfmetadata').persistentCode.trim();
+    if (persistentCode != '' && persistentCode == currentCode){
+      this.node.classList.add('df-cell-not-dirty');
+    }
+    else if(persistentCode != '') {
+      this.node.classList.remove('df-cell-not-dirty');
     }
   }
 }

--- a/packages/dfcells/src/widget.ts
+++ b/packages/dfcells/src/widget.ts
@@ -126,7 +126,7 @@ function setDFMetadata(cell: CodeCell) {
     const dfmetadata = {
       tag: "",
       inputVars: { ref: {}, tag_refs: {} },
-      outputVars: {},
+      outputVars: [],
       persistentCode: ""
     };
     cell.model.setMetadata('dfmetadata', dfmetadata);

--- a/packages/dfcells/src/widget.ts
+++ b/packages/dfcells/src/widget.ts
@@ -121,6 +121,18 @@ function setOutputArea(cell: CodeCell) {
   cell._output = dfOutput;
 }
 
+function setDFMetadata(cell: CodeCell) {
+  if (!cell.model.getMetadata('dfmetadata')){
+    const dfmetadata = {
+      tag: "",
+      inputVars: { ref: {}, tag_refs: {} },
+      outputVars: {},
+      persistentCode: ""
+    };
+    cell.model.setMetadata('dfmetadata', dfmetadata);
+  }
+}
+
 export class DataflowCell<T extends ICellModel = ICellModel> extends Cell<T> {
   protected initializeDOM(): void {
     super.initializeDOM();
@@ -152,6 +164,9 @@ export class DataflowMarkdownCell extends MarkdownCell {
     super.initializeDOM();
     setInputArea(this);
     this.addClass('df-cell');
+    if(this.model.getMetadata('dfmetadata')){
+      this.model.deleteMetadata('dfmetadata')
+    }
   }
 }
 
@@ -160,6 +175,9 @@ export class DataflowRawCell extends RawCell {
     super.initializeDOM();
     setInputArea(this);
     this.addClass('df-cell');
+    if(this.model.getMetadata('dfmetadata')){
+      this.model.deleteMetadata('dfmetadata')
+    }
   }
 }
 
@@ -180,6 +198,7 @@ export class DataflowCodeCell extends CodeCell {
     setOutputArea(this);
     this.setPromptToId();
     this.addClass('df-cell');
+    setDFMetadata(this);
   }
 
   public setPromptToId() {
@@ -250,7 +269,7 @@ export namespace DataflowCodeCell {
           cellIdOutputsMap[cellId] = cellIdModelMap[cellId].outputs;
         }
       }
-
+      
       const msgPromise = DataflowOutputArea.execute(
         code,
         cell.outputArea,
@@ -345,6 +364,7 @@ export namespace DataflowCodeCell {
       let internalNodes = content.internal_nodes;
       let sessId = sessionContext.session.id;
       let graphUndefined = false;
+      
       //Set information about the graph based on sessionid
       if(GraphManager.graphs[sessId] === undefined){
         GraphManager.createGraph(sessId);
@@ -357,7 +377,7 @@ export namespace DataflowCodeCell {
       }
 
        if (content.update_downstreams) {
-                    GraphManager.graphs[sessId].updateDownLinks(content.update_downstreams);
+          GraphManager.graphs[sessId].updateDownLinks(content.update_downstreams);
       }
 
       return msg;

--- a/packages/dfcells/style/base.css
+++ b/packages/dfcells/style/base.css
@@ -14,3 +14,19 @@
 .jp-CodeCell.jp-mod-outputsScrolled .jp-OutputArea-prompt {
   --jp-cell-prompt-width: var(--df-cell-prompt-width);
 }
+
+.jp-Notebook .jp-Cell.jp-mod-active.jp-mod-dirty.df-cell-not-dirty .jp-Collapser{
+  background: var(--jp-brand-color1);
+}
+
+.jp-Notebook .jp-Cell.jp-mod-dirty.df-cell-not-dirty .jp-InputPrompt {
+  color: var(--jp-cell-inprompt-font-color)
+}
+
+.jp-Notebook .jp-Cell:not(.jp-mod-active).jp-mod-dirty.df-cell-not-dirty .jp-InputPrompt {
+  color: var(--jp-cell-prompt-not-active-font-color);
+}
+
+.jp-Notebook .jp-Cell.jp-mod-dirty.df-cell-not-dirty .jp-InputPrompt::before {
+  content: none;
+}

--- a/packages/dfcells/test/widget.spec.ts
+++ b/packages/dfcells/test/widget.spec.ts
@@ -565,8 +565,7 @@ describe('cells/widget', () => {
           contentFactory
         });
 
-        widget['initializeDOM']();
-        
+        widget.initializeState();
         const dfmetadata = widget.model.getMetadata('dfmetadata');
         expect(dfmetadata).toBeDefined();
         expect(dfmetadata).toEqual(expect.objectContaining({
@@ -608,23 +607,27 @@ describe('cells/widget', () => {
           model: model1,
           rendermime,
           contentFactory
-        }).initializeState();
-  
+        })
+
+        widget1.initializeState();
+
         const model2 = new CodeCellModel();
         const widget2 = new CodeCell({
           model: model2,
           rendermime,
           contentFactory
-        }).initializeState();
+        })
         
+        widget2.initializeState();
+
         const dfmetadata1 = widget1.model.getMetadata('dfmetadata');
         const dfmetadata2 = widget2.model.getMetadata('dfmetadata');
         
         expect(dfmetadata1).toBeDefined();
         expect(dfmetadata2).toBeDefined();
         expect(dfmetadata1).not.toBe(dfmetadata2);
-        expect(dfmetadata1.outputVars).toBeInstanceOf(Set);
-        expect(dfmetadata2.outputVars).toBeInstanceOf(Set);
+        expect(dfmetadata1.outputVars).toBeInstanceOf(Array);
+        expect(dfmetadata2.outputVars).toBeInstanceOf(Array);
         expect(dfmetadata1.outputVars).not.toBe(dfmetadata2.outputVars);
       });
     });
@@ -927,7 +930,7 @@ describe('cells/widget', () => {
       it('should fire when model metadata changes', () => {
         const method = 'onMetadataChanged';
         const widget = new LogCodeCell().initializeState();
-        expect(widget.methods).not.toContain(method);
+        expect(widget.methods).not.toContain([method]);
         widget.model.setMetadata('foo', 1);
         expect(widget.methods).toContain(method);
       });

--- a/packages/dfcells/test/widget.spec.ts
+++ b/packages/dfcells/test/widget.spec.ts
@@ -556,6 +556,79 @@ describe('cells/widget', () => {
       });
     });
 
+    describe('#dfmetadata', () => {
+      it('should set dfmetadata when initializing', () => {
+        const model = new CodeCellModel();
+        const widget = new CodeCell({
+          model,
+          rendermime,
+          contentFactory
+        });
+
+        widget['initializeDOM']();
+        
+        const dfmetadata = widget.model.getMetadata('dfmetadata');
+        expect(dfmetadata).toBeDefined();
+        expect(dfmetadata).toEqual(expect.objectContaining({
+          tag: "",
+          inputVars: { ref: {}, tag_refs: {} },
+          outputVars: [],
+          persistentCode: ""
+        }));
+      });
+  
+      it('should not overwrite existing dfmetadata', () => {
+        const model = new CodeCellModel();
+        const existingDfmetadata = {
+          tag: "existing",
+          inputVars: { ref: { 'a': '1' }, tag_refs: { 'b': '2' } },
+          outputVars: ['c', 'd'],
+          persistentCode: "print('hello')"
+        };
+        model.setMetadata('dfmetadata', existingDfmetadata);
+  
+        const widget = new CodeCell({
+          model,
+          rendermime,
+          contentFactory
+        });
+
+        widget['initializeDOM']();
+        
+        const dfmetadata = widget.model.getMetadata('dfmetadata');
+        expect(dfmetadata.inputVars).toEqual(existingDfmetadata.inputVars);
+        expect(dfmetadata.outputVars.length).toBe(2);
+        expect(dfmetadata.outputVars).toEqual(existingDfmetadata.outputVars);
+        expect(dfmetadata.persistentCode).toBe("print('hello')");
+      });
+  
+      it('should set dfmetadata for multiple cells independently', () => {
+        const model1 = new CodeCellModel();
+        const widget1 = new CodeCell({
+          model: model1,
+          rendermime,
+          contentFactory
+        }).initializeState();
+  
+        const model2 = new CodeCellModel();
+        const widget2 = new CodeCell({
+          model: model2,
+          rendermime,
+          contentFactory
+        }).initializeState();
+        
+        const dfmetadata1 = widget1.model.getMetadata('dfmetadata');
+        const dfmetadata2 = widget2.model.getMetadata('dfmetadata');
+        
+        expect(dfmetadata1).toBeDefined();
+        expect(dfmetadata2).toBeDefined();
+        expect(dfmetadata1).not.toBe(dfmetadata2);
+        expect(dfmetadata1.outputVars).toBeInstanceOf(Set);
+        expect(dfmetadata2.outputVars).toBeInstanceOf(Set);
+        expect(dfmetadata1.outputVars).not.toBe(dfmetadata2.outputVars);
+      });
+    });
+
     describe('#outputArea', () => {
       it('should be the output area used by the cell', () => {
         const widget = new CodeCell({

--- a/packages/dfgraph/src/dfgraph.ts
+++ b/packages/dfgraph/src/dfgraph.ts
@@ -258,9 +258,11 @@ export class Graph {
     that.executed[uuid] = true;
     //We have to execute upstreams either way
     console.log(that.uplinks[uuid]);
-    Object.keys(that.uplinks[uuid]).forEach(function (upuuid: string) {
-      that.states[upuuid] = 'Fresh';
-    });
+    if(that.uplinks[uuid]){
+      Object.keys(that.uplinks[uuid]).forEach(function (upuuid: string) {
+        that.states[upuuid] = 'Fresh';
+      });
+    }
 
     if (revert == true) {
       //Restore downstream statuses

--- a/packages/dfgraph/src/dfgraph.ts
+++ b/packages/dfgraph/src/dfgraph.ts
@@ -303,7 +303,7 @@ export class Graph {
     //         }
     that.cells = cells;
     that.nodes[uuid] = nodes || [];
-    if (uuid in that.uplinks) {
+    if (uuid in that.uplinks && that.uplinks[uuid]) {
       Object.keys(that.uplinks[uuid]).forEach(function (uplink) {
         that.downlinks[uplink] = [];
       });

--- a/packages/dfgraph/src/dfgraph.ts
+++ b/packages/dfgraph/src/dfgraph.ts
@@ -71,7 +71,7 @@ class GraphManager {
     //         if(this.depWidget.is_open){
     //             console.log("Update dep viewer here");
     //         }
-    if (this.miniWidget.isOpen) {
+    if (this.miniWidget && this.miniWidget.isOpen) {
       this.minimap.updateActiveByID(activeid);
     }
   };
@@ -145,7 +145,7 @@ class GraphManager {
     mini: boolean = false,
     mini2: boolean = false
   ) {
-    if (this.miniWidget.isOpen) {
+    if (this.miniWidget && this.miniWidget.isOpen) {
       if (mini2) {
         return;
       }
@@ -154,7 +154,7 @@ class GraphManager {
       }
       this.minimap.startMinimapCreation();
     }
-    if (this.depWidget.isOpen && !mini) {
+    if (this.depwidget && this.depWidget.isOpen && !mini) {
       if (newView) {
         this.depview.startGraphCreation();
       } else {

--- a/packages/dfnotebook-extension/package.json
+++ b/packages/dfnotebook-extension/package.json
@@ -37,7 +37,6 @@
     "schema/*.json",
     "style/*.css",
     "style/index.js",
-    "src/**/*.{ts,tsx}",
     "src/**/*.{d.ts,ts,tsx}",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
   ],

--- a/packages/dfnotebook-extension/package.json
+++ b/packages/dfnotebook-extension/package.json
@@ -37,7 +37,9 @@
     "schema/*.json",
     "style/*.css",
     "style/index.js",
-    "src/**/*.{ts,tsx}"
+    "src/**/*.{ts,tsx}",
+    "src/**/*.{d.ts,ts,tsx}",
+    "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
   ],
   "scripts": {
     "build": "jlpm build:lib && jlpm build:labextension:dev",

--- a/packages/dfnotebook-extension/package.json
+++ b/packages/dfnotebook-extension/package.json
@@ -36,6 +36,7 @@
     "lib/**/*.js",
     "schema/*.json",
     "style/*.css",
+    "style/tag.svg",
     "style/index.js",
     "src/**/*.{d.ts,ts,tsx}",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"

--- a/packages/dfnotebook-extension/schema/tracker.json
+++ b/packages/dfnotebook-extension/schema/tracker.json
@@ -5,12 +5,21 @@
     "main": [
       {
         "id": "jp-mainmenu-edit",
-        "items": [{ "command": "notebook:tag-cell", "rank": 9 }]
+        "items": [{ "command": "notebook:add-cell-tag", "rank": 9 }]
+      },
+      {
+        "id": "jp-mainmenu-edit",
+        "items": [{ "command": "notebook:modify-cell-tag", "rank": 9 }]
       }
     ],
     "context": [
       {
-        "command": "notebook:tag-cell",
+        "command": "notebook:add-cell-tag",
+        "selector": ".jp-Notebook .jp-Cell",
+        "rank": 7
+      },
+      {
+        "command": "notebook:modify-cell-tag",
         "selector": ".jp-Notebook .jp-Cell",
         "rank": 7
       }

--- a/packages/dfnotebook-extension/schema/tracker.json
+++ b/packages/dfnotebook-extension/schema/tracker.json
@@ -25,6 +25,15 @@
       }
     ]
   },
+  "jupyter.lab.toolbars": {
+    "Cell": [
+      {
+        "name": "tag",
+        "command": "toolbar-button:tag-cell",
+        "rank": 1
+      }
+    ]
+  },
   "title": "Dataflow Notebook",
   "description": "Dataflow Notebook settings.",
   "definitions": {

--- a/packages/dfnotebook-extension/src/svg.d.ts
+++ b/packages/dfnotebook-extension/src/svg.d.ts
@@ -1,0 +1,4 @@
+declare module '*.svg' {
+    const value: string;
+    export default value;
+}

--- a/packages/dfnotebook-extension/style/base.css
+++ b/packages/dfnotebook-extension/style/base.css
@@ -7,3 +7,74 @@
 :root {
   --df-cell-prompt-width: 128px;
 }
+
+.jupyter-toggle-switch-widget {
+  display: flex;
+  align-items: center;
+  padding: 0 8px;
+}
+
+.toggle-container {
+  display: flex;
+  align-items: center;
+}
+
+.toggle-label {
+  margin-right: 10px;
+}
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 20px;
+  margin-top: 3px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  transition: .4s;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 15px;
+  width: 15px;
+  left: 2px;
+  bottom: 2.5px;
+  background-color: white;
+  transition: .4s;
+}
+
+input:checked + .slider {
+  background-color: #e9812be3;
+}
+
+input:focus + .slider {
+  box-shadow: 0 0 1px #e9812be3;
+}
+
+input:checked + .slider:before {
+  transform: translateX(21px);
+}
+
+.slider.round {
+  border-radius: 20px;
+}
+
+.slider.round:before {
+  border-radius: 50%;
+}

--- a/packages/dfnotebook-extension/style/base.css
+++ b/packages/dfnotebook-extension/style/base.css
@@ -78,3 +78,7 @@ input:checked + .slider:before {
 .slider.round:before {
   border-radius: 50%;
 }
+
+.tag-icon{
+  fill: none !important;
+}

--- a/packages/dfnotebook-extension/style/tag.svg
+++ b/packages/dfnotebook-extension/style/tag.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
+  <!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.-->
+  <path d="M0 80L0 229.5c0 17 6.7 33.3 18.7 45.3l176 176c25 25 65.5 25 90.5 0L418.7 317.3c25-25 25-65.5 0-90.5l-176-176c-12-12-28.3-18.7-45.3-18.7L48 32C21.5 32 0 53.5 0 80zm112 32a32 32 0 1 1 0 64 32 32 0 1 1 0-64z" class="jp-icon3 tag-icon" stroke="#616161" stroke-width="50"></path>
+</svg>

--- a/packages/dfnotebook/src/cellexecutor.ts
+++ b/packages/dfnotebook/src/cellexecutor.ts
@@ -184,7 +184,7 @@ import { notebookCellMap, getNotebookId } from '@dfnotebook/dfcells';
       const response = await dfCommGetData(sessionContext, {'dfMetadata': dfData.dfMetadata});
       console.log('Received data from kernel:', response);
       if (response?.code_dict && Object.keys(response.code_dict).length > 0) {
-        updateNotebookCells(notebook, notebookId, response.code_dict);
+        await updateNotebookCells(notebook, notebookId, response.code_dict);
       }
     } catch (error) {
       console.error('Error during kernel communication:', error);
@@ -207,7 +207,7 @@ import { notebookCellMap, getNotebookId } from '@dfnotebook/dfcells';
     });
   }
 
-  function updateNotebookCells(notebook: DataflowNotebookModel, notebookId:string|undefined, codeDict: { [key: string]: any }) {
+  async function updateNotebookCells(notebook: DataflowNotebookModel, notebookId:string|undefined, codeDict: { [key: string]: any }) {
     const cellMap = notebookId ? notebookCellMap.get(notebookId) : undefined;
     const cellsArray = Array.from(notebook.cells);
     cellsArray.forEach(cell => {

--- a/packages/dfnotebook/src/cellexecutor.ts
+++ b/packages/dfnotebook/src/cellexecutor.ts
@@ -119,9 +119,6 @@ import { DataflowNotebookModel } from './model';
                   if (cAny.type === 'code') {
                     const cId = cAny.id.replace(/-/g, '').substring(0, 8);
                     const dfmetadata = cAny.getMetadata('dfmetadata');
-                    if(content.persistent_code[cId]){
-                      dfmetadata.persistentCode = cAny.sharedModel.getSource();
-                    }
                     
                     if(content.identifier_refs[cId]){
                       let inputVarsMetadata = { 'ref': {}, 'tag_refs': {}};
@@ -135,15 +132,17 @@ import { DataflowNotebookModel } from './model';
                       }
                       inputVarsMetadata.tag_refs = tag_refs;
                       dfmetadata.inputVars = inputVarsMetadata;
+                      dfmetadata.persistentCode = cAny.sharedModel.getSource();
                     }
                 
-                    if(content.persistent_code[cId] || content.identifier_refs[cId]){
+                    if(content.identifier_refs[cId]){
                       let cellOutputTags: string[] = [];
                       for (let i = 0; i < cAny.outputs.length; ++i) {
                         const out = cAny.outputs.get(i);
                         cellOutputTags.push(out.metadata['output_tag'] as string);
                       }
                       dfmetadata.outputVars = cellOutputTags;
+                      dfmetadata.persistentCode = cAny.sharedModel.getSource();
                     }
                     notebook.cells.get(index).setMetadata('dfmetadata', dfmetadata);
                   }

--- a/packages/dfnotebook/src/cellexecutor.ts
+++ b/packages/dfnotebook/src/cellexecutor.ts
@@ -120,9 +120,9 @@ import { DataflowNotebookModel } from './model';
                     const cId = cAny.id.replace(/-/g, '').substring(0, 8);
                     const dfmetadata = cAny.getMetadata('dfmetadata');
                     if(content.persistent_code[cId]){
-                      dfmetadata.persistentCode = content.persistent_code[cId];
+                      dfmetadata.persistentCode = cAny.sharedModel.getSource();
                     }
-                
+                    
                     if(content.identifier_refs[cId]){
                       let inputVarsMetadata = { 'ref': {}, 'tag_refs': {}};
                       inputVarsMetadata.ref = content.identifier_refs[cId];
@@ -169,7 +169,11 @@ import { DataflowNotebookModel } from './model';
                         const cAny = notebook.cells.get(index) as ICodeCellModel;
                         const cId = cAny.id.replace(/-/g, '').substring(0, 8);
                         if (cAny.type === 'code' && content.code_dict.hasOwnProperty(cId)) {
-                          cAny.sharedModel.setSource((content.code_dict as { [key: string]: any })[cId]);
+                          let updatedCode = (content.code_dict as { [key: string]: any })[cId]
+                          let dfmetadata = cAny.getMetadata('dfmetadata')
+                          dfmetadata.persistentCode = updatedCode;
+                          cAny.setMetadata('dfmetadata', dfmetadata);
+                          cAny.sharedModel.setSource(updatedCode);
                         }
                       }
                     }

--- a/packages/dfnotebook/src/model.ts
+++ b/packages/dfnotebook/src/model.ts
@@ -14,6 +14,7 @@ export class DataflowNotebookModel extends NotebookModel {
     }
     super.fromJSON(value);
     this.setMetadata('dfnotebook', isDataflow);
+    this.setMetadata('enable_tags', true);
   }
 
 }

--- a/packages/dfnotebook/test/cellexecutor.spec.ts
+++ b/packages/dfnotebook/test/cellexecutor.spec.ts
@@ -1,0 +1,625 @@
+import { runCell } from '../src/cellexecutor';
+import { type ICodeCellModel } from '@jupyterlab/cells';
+import { SessionContext, ISessionContext } from '@jupyterlab/apputils';
+import { DataflowCodeCell } from '@dfnotebook/dfcells';
+import { createSessionContext } from '@jupyterlab/apputils/lib/testutils';
+import { JupyterServer } from '@jupyterlab/testing';
+import { DataflowNotebookModel, DataflowNotebook as Notebook } from '../src';
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import * as utils from './utils';
+import { INotebookModel, StaticNotebook as StaticNotebookType } from '@jupyterlab/notebook';
+import { NBTestUtils } from '@jupyterlab/notebook/lib/testutils';
+import { updateNotebookCellsWithTag }  from '../../dfnotebook-extension/src/index'
+
+describe('Identifier reference update', () => {
+  let sessionContext: ISessionContext;
+  const server = new JupyterServer();
+  let widget: Notebook;
+  let rendermime: IRenderMimeRegistry;
+  let notebook: INotebookModel;
+  
+  beforeAll(async () => {
+    rendermime = utils.defaultRenderMime();
+    await server.start({'additionalKernelSpecs':{'dfpython3':{'argv':['python','-m','dfkernel','-f','{connection_file}'],'display_name':'DFPython 3','language':'python'}}});
+    sessionContext = await createSessionContext(
+      {'kernelPreference':
+      {'name':'dfpython3','autoStartDefault':true,'shouldStart':true}});
+  
+    await (sessionContext as SessionContext).initialize();
+    await sessionContext.session?.kernel?.info;
+    await sessionContext.session?.id;
+    await sessionContext.startKernel();
+  }, 30000);
+
+  afterAll(async () => {
+    await server.shutdown();
+  });
+  
+  beforeEach(async () => {
+    widget = new Notebook({
+      rendermime,
+      contentFactory: utils.createNotebookFactory(),
+      mimeTypeService: utils.mimeTypeService,
+      notebookConfig: {
+        ...StaticNotebookType.defaultNotebookConfig,
+        windowingMode: 'none'
+      }
+    });
+    const model = new DataflowNotebookModel();
+    widget.model = model;
+    model.sharedModel.clearUndoHistory();
+    widget.activeCellIndex = 0;
+
+    notebook = widget.model;
+    if (!notebook) {
+      throw new Error('Notebook model is null');
+    }
+  });
+    
+  afterEach(() => {
+    return sessionContext.shutdown();
+  });
+
+  async function runNotebookCell(notebook: INotebookModel, cellModel: ICodeCellModel) {
+    const cell = new DataflowCodeCell({
+      model: cellModel,
+      rendermime: rendermime,
+      contentFactory: NBTestUtils.createBaseCellFactory()
+    });
+
+    const result = await runCell({
+      cell,
+      notebook,
+      sessionContext,
+      notebookConfig: {
+        defaultCell: 'code',
+        disableDocumentWideUndoRedo: false,
+        enableKernelInitNotification: true,
+        maxNumberOutputs: 50,
+        windowingMode: 'none',
+        scrollPastEnd: true,
+        showHiddenCellsButton: false,
+        recordTiming: false,
+        overscanCount: 1,
+        renderingLayout: 'default',
+        inputHistoryScope: 'session',
+        sideBySideLeftMarginOverride: 'none',
+        sideBySideRightMarginOverride: 'none',
+        sideBySideOutputRatio: 0
+      },
+      onCellExecuted: ({ cell, success, error }) => {
+        console.log(`Cell executed: ${success}`);
+        if (error) {
+          console.error(error);
+        }
+      },
+      onCellExecutionScheduled: ({ cell }) => {
+        console.log('Cell execution scheduled');
+      }
+    });
+
+    return result;
+  }
+
+  describe('Update references with UUID', () => {
+    it('Reference UUID is not added when identifier is exported only once', async () => {
+      // Code cell 1
+      notebook.sharedModel.insertCell(0, {
+        cell_type: 'code',
+        source: 'a=9',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      let cellModel = notebook?.cells.get(0) as ICodeCellModel;
+      let result = await runNotebookCell(notebook, cellModel);
+      
+      // verifies code cell execution
+      let cAny = notebook?.cells.get(0) as ICodeCellModel;
+      expect(result).toBe(true);
+      expect(cAny.outputs.length).toBe(1);
+      expect(cAny.outputs.get(0).data['text/plain']).toBe('9');
+  
+      //Code cell 2
+      notebook.sharedModel.insertCell(1, {
+        cell_type: 'code',
+        source: 'b=a+9',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      cellModel = notebook?.cells.get(1) as ICodeCellModel;
+      result = await runNotebookCell(notebook, cellModel);
+  
+      // verifies no ref UUID is added for identifier 'a' since it is exported only once
+      cAny = notebook?.cells.get(1) as ICodeCellModel;
+      expect(result).toBe(true);
+      expect(cAny.outputs.length).toBe(1);
+      expect(cAny.outputs.get(0).data['text/plain']).toBe('18');
+      expect(cAny.sharedModel.source).toBe('b=a+9');
+    });
+  
+    it('Reference UUID is not removed when ambiguity exist', async () => {
+      // Code cell 1
+      notebook?.sharedModel.insertCell(0, {
+        cell_type: 'code',
+        source: 'a=9',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      let cellModel = notebook?.cells.get(0) as ICodeCellModel;
+      let result = await runNotebookCell(notebook, cellModel);
+      const refId = (notebook?.cells.get(0) as ICodeCellModel).id.replace(/-/g, '').substring(0, 8);
+      //Code cell 2
+      notebook?.sharedModel.insertCell(1, {
+        cell_type: 'code',
+        source: 'a=5\ntest=a+99\nb=a$'+refId+'+99',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      cellModel = notebook?.cells.get(1) as ICodeCellModel;
+      result = await runNotebookCell(notebook, cellModel);
+      
+      let cAny = notebook?.cells.get(1) as ICodeCellModel;
+      expect(result).toBe(true);
+      expect(cAny.outputs.length).toBe(1);
+      expect(cAny.outputs.get(0).data['text/plain']).toBe('108');
+      expect(cAny.sharedModel.source).toBe('a=5\ntest=a+99\nb=a$'+refId+'+99');
+    });
+  
+    it('Dfmetadata should be updated with references', async () => {
+      // Code cell 1
+      notebook?.sharedModel.insertCell(0, {
+        cell_type: 'code',
+        source: 'a=9',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      let cellModel = notebook?.cells.get(0) as ICodeCellModel;
+      let result = await runNotebookCell(notebook, cellModel);
+      expect(result).toBe(true);
+  
+      //Code cell 2
+      notebook?.sharedModel.insertCell(1, {
+        cell_type: 'code',
+        source: 'b=a+9',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      cellModel = notebook?.cells.get(1) as ICodeCellModel;
+      result = await runNotebookCell(notebook, cellModel);
+  
+      let cAny = notebook?.cells.get(1) as ICodeCellModel;
+      const refId = (notebook?.cells.get(0) as ICodeCellModel).id.replace(/-/g, '').substring(0, 8);
+      let dfmetadata = cAny.getMetadata("dfmetadata")
+      expect(result).toBe(true);    
+      expect(dfmetadata).toBeDefined();
+      expect(dfmetadata.inputVars).toEqual({
+        "ref": {
+          [refId]: ["a"]
+        },
+        "tag_refs": {}
+      });
+      expect(dfmetadata.outputVars).toEqual(['b'])
+    });
+  
+    it('Reference UUID is added when same identifier exported more than once', async () => {
+      // Code cell 1
+      notebook?.sharedModel.insertCell(0, {
+        cell_type: 'code',
+        source: 'a=9',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      let cellModel = notebook?.cells.get(0) as ICodeCellModel;
+      let result = await runNotebookCell(notebook, cellModel);
+      expect(result).toBe(true);
+  
+      //Code cell 2
+      notebook?.sharedModel.insertCell(1, {
+        cell_type: 'code',
+        source: 'b=a+9',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      cellModel = notebook?.cells.get(1) as ICodeCellModel;
+      result = await runNotebookCell(notebook, cellModel);
+      expect(result).toBe(true);
+      
+      //Code cell 3
+      notebook?.sharedModel.insertCell(2, {
+        cell_type: 'code',
+        source: 'a=9',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      cellModel = notebook?.cells.get(2) as ICodeCellModel;
+      result = await runNotebookCell(notebook, cellModel);
+      
+      let cAny = notebook?.cells.get(1) as ICodeCellModel;
+      const refId = (notebook?.cells.get(0) as ICodeCellModel).id.replace(/-/g, '').substring(0, 8);
+      expect(result).toBe(true);
+      expect(cAny.sharedModel.source).toBe('b=a$'+refId+'+9');
+    });
+
+    it('When an identifier is exported multiple times and later reduced to one, the UUID is removed', async () => {
+      // Code cell 1
+      notebook?.sharedModel.insertCell(0, {
+        cell_type: 'code',
+        source: 'a=9',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      let cellModel = notebook?.cells.get(0) as ICodeCellModel;
+      let result = await runNotebookCell(notebook, cellModel);
+      expect(result).toBe(true);
+  
+      //Code cell 2
+      notebook?.sharedModel.insertCell(1, {
+        cell_type: 'code',
+        source: 'b=a+9',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      cellModel = notebook?.cells.get(1) as ICodeCellModel;
+      result = await runNotebookCell(notebook, cellModel);
+      expect(result).toBe(true);
+      
+      //Code cell 3
+      notebook?.sharedModel.insertCell(2, {
+        cell_type: 'code',
+        source: 'a=9',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      cellModel = notebook?.cells.get(2) as ICodeCellModel;
+      result = await runNotebookCell(notebook, cellModel);
+      
+      let cAny = notebook?.cells.get(1) as ICodeCellModel;
+      const refId = (notebook?.cells.get(0) as ICodeCellModel).id.replace(/-/g, '').substring(0, 8);
+      expect(result).toBe(true);
+      expect(cAny.sharedModel.source).toBe('b=a$'+refId+'+9');
+
+      //deleting code cell 2
+      notebook.sharedModel.deleteCell(2)
+
+      cellModel = notebook?.cells.get(0) as ICodeCellModel;
+      result = await runNotebookCell(notebook, cellModel);
+      expect(result).toBe(true);
+      expect(cAny.sharedModel.source).toBe('b=a+9');
+    });
+  
+    it('Reference UUID is added to identifier when its reference cell is deleted', async () => {
+      // Code cell 1
+      notebook?.sharedModel.insertCell(0, {
+        cell_type: 'code',
+        source: 'a=9',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      let cellModel = notebook?.cells.get(0) as ICodeCellModel;
+      let result = await runNotebookCell(notebook, cellModel);
+      const refId = (notebook?.cells.get(0) as ICodeCellModel).id.replace(/-/g, '').substring(0, 8);
+      expect(result).toBe(true);
+  
+      //Code cell 2
+      notebook?.sharedModel.insertCell(1, {
+        cell_type: 'code',
+        source: 'b=a+9',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      cellModel = notebook?.cells.get(1) as ICodeCellModel;
+      result = await runNotebookCell(notebook, cellModel);
+      expect(result).toBe(true);
+  
+      notebook.sharedModel.deleteCellRange(0,1);
+      
+      //Code cell 3
+      notebook?.sharedModel.insertCell(1, {
+        cell_type: 'code',
+        source: 'h=9',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      cellModel = notebook?.cells.get(1) as ICodeCellModel;
+      result = await runNotebookCell(notebook, cellModel);
+  
+      let cAny = notebook?.cells.get(0) as ICodeCellModel;
+      expect(result).toBe(true);
+      expect(cAny.sharedModel.source).toBe('b=a$'+refId+'+9');
+    })
+  
+    it('Reference UUID is added to identifier when its ref is removed by updating cell', async () => {
+      // Code cell 1
+      notebook?.sharedModel.insertCell(0, {
+        cell_type: 'code',
+        source: 'a=9',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      let cellModel = notebook?.cells.get(0) as ICodeCellModel;
+      let result = await runNotebookCell(notebook, cellModel);
+      expect(result).toBe(true);
+  
+      //Code cell 2
+      notebook?.sharedModel.insertCell(1, {
+        cell_type: 'code',
+        source: 'b=a+9',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      cellModel = notebook?.cells.get(1) as ICodeCellModel;
+      result = await runNotebookCell(notebook, cellModel);
+      expect(result).toBe(true);
+      
+      //Running cell 1
+      cellModel = notebook?.cells.get(0) as ICodeCellModel;
+      cellModel.sharedModel.setSource('k=0');
+      result = await runNotebookCell(notebook, cellModel);
+  
+      let cAny = notebook?.cells.get(1) as ICodeCellModel;
+      const refId = (notebook?.cells.get(0) as ICodeCellModel).id.replace(/-/g, '').substring(0, 8);
+      expect(result).toBe(true);
+      expect(cAny.sharedModel.source).toBe('b=a$'+refId+'+9');
+    })
+  });
+
+  describe('Update references with Tags', () => {
+    it('Should able to use tag as identifier ref', async () => {
+      // Code cell 1
+      notebook.setMetadata("enable_tags", true);
+      notebook?.sharedModel.insertCell(0, {
+        cell_type: 'code',
+        source: 'a=9',
+        metadata: {
+          trusted: false
+        }
+      });
+
+      let cellModel = notebook?.cells.get(0) as ICodeCellModel;
+      let result = await runNotebookCell(notebook, cellModel);
+      expect(result).toBe(true);
+
+      let dfmetadata = (notebook?.cells.get(0) as ICodeCellModel).getMetadata('dfmetadata');
+      dfmetadata.tag = "Tag1";
+      notebook.cells.get(0).setMetadata('dfmetadata', dfmetadata);
+
+      notebook?.sharedModel.insertCell(1, {
+        cell_type: 'code',
+        source: 'a=5\ntest=a+99\nb=a$Tag1+99',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      cellModel = notebook?.cells.get(1) as ICodeCellModel;
+      result = await runNotebookCell(notebook, cellModel);
+      
+      let cAny = notebook?.cells.get(1) as ICodeCellModel;
+      expect(result).toBe(true);
+      expect(cAny.outputs.length).toBe(1);
+      expect(cAny.outputs.get(0).data['text/plain']).toBe('108');
+      expect(cAny.sharedModel.source).toBe('a=5\ntest=a+99\nb=a$Tag1+99');
+    });
+  
+    it('CellId should be replaced with tag in codecells when tag is added', async () => {
+      // Code cell 1
+      notebook.setMetadata("enable_tags", true);
+      notebook?.sharedModel.insertCell(0, {
+        cell_type: 'code',
+        source: 'a=9',
+        metadata: {
+          trusted: false
+        }
+      });
+
+      let cellModel = notebook?.cells.get(0) as ICodeCellModel;
+      const refId = (notebook?.cells.get(0) as ICodeCellModel).id.replace(/-/g, '').substring(0, 8);
+      let result = await runNotebookCell(notebook, cellModel);
+      expect(result).toBe(true);
+
+      notebook?.sharedModel.insertCell(1, {
+        cell_type: 'code',
+        source: 'a=5\ntest=a+99\nb=a$'+refId+'+99',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      cellModel = notebook?.cells.get(1) as ICodeCellModel;
+      result = await runNotebookCell(notebook, cellModel);
+      expect(result).toBe(true);
+
+      let dfmetadata = (notebook?.cells.get(0) as ICodeCellModel).getMetadata('dfmetadata');
+      dfmetadata.tag = "Tag1";
+      notebook.cells.get(0).setMetadata('dfmetadata', dfmetadata);
+
+      await updateNotebookCellsWithTag(notebook as DataflowNotebookModel, '', sessionContext)
+      
+      let cAny = notebook?.cells.get(1) as ICodeCellModel;
+      expect(cAny.sharedModel.source).toBe('a=5\ntest=a+99\nb=a$Tag1+99');
+    });
+
+    it('Dfmetadata should be updated with tag references', async () => {
+      // Code cell 1
+      notebook.setMetadata("enable_tags", true);
+      notebook?.sharedModel.insertCell(0, {
+        cell_type: 'code',
+        source: 'a=9',
+        metadata: {
+          trusted: false
+        }
+      });
+
+      let cellModel = notebook?.cells.get(0) as ICodeCellModel;
+      let result = await runNotebookCell(notebook, cellModel);
+      expect(result).toBe(true);
+
+      let dfmetadata = (notebook?.cells.get(0) as ICodeCellModel).getMetadata('dfmetadata');
+      dfmetadata.tag = "Tag1";
+      notebook.cells.get(0).setMetadata('dfmetadata', dfmetadata);
+
+      notebook?.sharedModel.insertCell(1, {
+        cell_type: 'code',
+        source: 'a=5\ntest=a+99\nb=a$Tag1+99',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      cellModel = notebook?.cells.get(1) as ICodeCellModel;
+      result = await runNotebookCell(notebook, cellModel);
+      
+      let cAny = notebook?.cells.get(1) as ICodeCellModel;
+      const refId = (notebook?.cells.get(0) as ICodeCellModel).id.replace(/-/g, '').substring(0, 8);
+      dfmetadata = cAny.sharedModel.getMetadata('dfmetadata')
+      
+      expect(result).toBe(true);
+      expect(cAny.outputs.length).toBe(1);
+      expect(cAny.outputs.get(0).data['text/plain']).toBe('108');
+      expect(cAny.sharedModel.source).toBe('a=5\ntest=a+99\nb=a$Tag1+99');
+      expect(dfmetadata).toBeDefined();
+      expect(dfmetadata.inputVars).toEqual({
+        "ref": {
+          [refId]: ["a"]
+        },
+        "tag_refs": {
+          [refId]: "Tag1"
+        }
+      });
+    });
+  
+    it('Tag should be replaced with UUID when tag is removed', async () => {
+      // Code cell 1
+      notebook.setMetadata("enable_tags", true);
+      notebook?.sharedModel.insertCell(0, {
+        cell_type: 'code',
+        source: 'a=9',
+        metadata: {
+          trusted: false
+        }
+      });
+
+      let cellModel = notebook?.cells.get(0) as ICodeCellModel;
+      let result = await runNotebookCell(notebook, cellModel);
+      expect(result).toBe(true);
+
+      const refId = (notebook?.cells.get(0) as ICodeCellModel).id.replace(/-/g, '').substring(0, 8);
+      let dfmetadata = (notebook?.cells.get(0) as ICodeCellModel).getMetadata('dfmetadata');
+      dfmetadata.tag = "Tag1";
+      notebook.cells.get(0).setMetadata('dfmetadata', dfmetadata);
+
+      notebook?.sharedModel.insertCell(1, {
+        cell_type: 'code',
+        source: 'a=5\ntest=a+99\nb=a$Tag1+99',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      cellModel = notebook?.cells.get(1) as ICodeCellModel;
+      result = await runNotebookCell(notebook, cellModel);
+      expect(result).toBe(true);
+
+      //deleting tag
+      dfmetadata = (notebook?.cells.get(0) as ICodeCellModel).getMetadata('dfmetadata');
+      dfmetadata.tag = "";
+      notebook.cells.get(0).setMetadata('dfmetadata', dfmetadata);
+
+      await updateNotebookCellsWithTag(notebook as DataflowNotebookModel, refId, sessionContext)
+
+      let cAny = notebook?.cells.get(1) as ICodeCellModel;
+      expect(cAny.outputs.length).toBe(1);
+      expect(cAny.outputs.get(0).data['text/plain']).toBe('108');
+      expect(cAny.sharedModel.source).toBe('a=5\ntest=a+99\nb=a$'+refId+'+99');
+    })
+
+    it('Tag should be replaced with UUID when tagged cell is deleted', async () => {
+      // Code cell 1
+      notebook.setMetadata("enable_tags", true);
+      notebook?.sharedModel.insertCell(0, {
+        cell_type: 'code',
+        source: 'a=9',
+        metadata: {
+          trusted: false
+        }
+      });
+
+      let cellModel = notebook?.cells.get(0) as ICodeCellModel;
+      let result = await runNotebookCell(notebook, cellModel);
+      expect(result).toBe(true);
+
+      const refId = (notebook?.cells.get(0) as ICodeCellModel).id.replace(/-/g, '').substring(0, 8);
+      let dfmetadata = (notebook?.cells.get(0) as ICodeCellModel).getMetadata('dfmetadata');
+      dfmetadata.tag = "Tag1";
+      notebook.cells.get(0).setMetadata('dfmetadata', dfmetadata);
+
+      // Code cell 2
+      notebook?.sharedModel.insertCell(1, {
+        cell_type: 'code',
+        source: 'a=5\ntest=a+99\nb=a$Tag1+99',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      cellModel = notebook?.cells.get(1) as ICodeCellModel;
+      result = await runNotebookCell(notebook, cellModel);
+      expect(result).toBe(true);
+
+      //deleting code cell 1
+      notebook.sharedModel.deleteCellRange(0,1)
+
+      // Code cell 3
+      notebook?.sharedModel.insertCell(1, {
+        cell_type: 'code',
+        source: 's = "test"',
+        metadata: {
+          trusted: false
+        }
+      });
+  
+      cellModel = notebook?.cells.get(1) as ICodeCellModel;
+      result = await runNotebookCell(notebook, cellModel);
+      expect(result).toBe(true);
+      
+      let cAny = notebook?.cells.get(0) as ICodeCellModel;
+      expect(cAny.sharedModel.source).toBe('a=5\ntest=a+99\nb=a$'+refId+'+99');
+    })
+
+  });
+
+});

--- a/packages/dfnotebook/test/cellexecutor.spec.ts
+++ b/packages/dfnotebook/test/cellexecutor.spec.ts
@@ -1,15 +1,16 @@
 import { runCell } from '../src/cellexecutor';
 import { type ICodeCellModel } from '@jupyterlab/cells';
 import { SessionContext, ISessionContext } from '@jupyterlab/apputils';
-import { DataflowCodeCell } from '@dfnotebook/dfcells';
+import { DataflowCodeCell, getNotebookId, notebookCellMap } from '@dfnotebook/dfcells';
 import { createSessionContext } from '@jupyterlab/apputils/lib/testutils';
 import { JupyterServer } from '@jupyterlab/testing';
 import { DataflowNotebookModel, DataflowNotebook as Notebook } from '../src';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import * as utils from './utils';
-import { INotebookModel, StaticNotebook as StaticNotebookType } from '@jupyterlab/notebook';
+import { INotebookModel, NotebookPanel, StaticNotebook as StaticNotebookType } from '@jupyterlab/notebook';
 import { NBTestUtils } from '@jupyterlab/notebook/lib/testutils';
-import { updateNotebookCellsWithTag }  from '../../dfnotebook-extension/src/index'
+import { Context } from '@jupyterlab/docregistry';
+import { updateNotebookCellsWithTag }  from '../../dfnotebook-extension/src/index';
 
 describe('Identifier reference update', () => {
   let sessionContext: ISessionContext;
@@ -17,7 +18,9 @@ describe('Identifier reference update', () => {
   let widget: Notebook;
   let rendermime: IRenderMimeRegistry;
   let notebook: INotebookModel;
-  
+  let context: Context<INotebookModel>;
+  let panel: NotebookPanel;
+
   beforeAll(async () => {
     rendermime = utils.defaultRenderMime();
     await server.start({'additionalKernelSpecs':{'dfpython3':{'argv':['python','-m','dfkernel','-f','{connection_file}'],'display_name':'DFPython 3','language':'python'}}});
@@ -45,6 +48,10 @@ describe('Identifier reference update', () => {
         windowingMode: 'none'
       }
     });
+    context = await utils.createMockContext();
+    panel = utils.createNotebookPanel(context);
+    panel.id = 'mock-notebook-panel';
+    
     const model = new DataflowNotebookModel();
     widget.model = model;
     model.sharedModel.clearUndoHistory();
@@ -66,6 +73,12 @@ describe('Identifier reference update', () => {
       rendermime: rendermime,
       contentFactory: NBTestUtils.createBaseCellFactory()
     });
+
+    cell.parent = panel;
+    let notebookId = getNotebookId(cell as DataflowCodeCell);
+    if(notebookId){
+      notebookCellMap.set(notebookId, new Map<string, string>());
+    }
 
     const result = await runCell({
       cell,
@@ -111,7 +124,7 @@ describe('Identifier reference update', () => {
           trusted: false
         }
       });
-  
+
       let cellModel = notebook?.cells.get(0) as ICodeCellModel;
       let result = await runNotebookCell(notebook, cellModel);
       
@@ -222,7 +235,7 @@ describe('Identifier reference update', () => {
           trusted: false
         }
       });
-  
+
       let cellModel = notebook?.cells.get(0) as ICodeCellModel;
       let result = await runNotebookCell(notebook, cellModel);
       expect(result).toBe(true);
@@ -251,6 +264,7 @@ describe('Identifier reference update', () => {
   
       cellModel = notebook?.cells.get(2) as ICodeCellModel;
       result = await runNotebookCell(notebook, cellModel);
+      expect(result).toBe(true);
       
       let cAny = notebook?.cells.get(1) as ICodeCellModel;
       const refId = (notebook?.cells.get(0) as ICodeCellModel).id.replace(/-/g, '').substring(0, 8);

--- a/packages/dfnotebook/test/cellexecutor.spec.ts
+++ b/packages/dfnotebook/test/cellexecutor.spec.ts
@@ -467,7 +467,7 @@ describe('Identifier reference update', () => {
       dfmetadata.tag = "Tag1";
       notebook.cells.get(0).setMetadata('dfmetadata', dfmetadata);
 
-      await updateNotebookCellsWithTag(notebook as DataflowNotebookModel, '', sessionContext)
+      await updateNotebookCellsWithTag("", notebook as DataflowNotebookModel, '', sessionContext)
       
       let cAny = notebook?.cells.get(1) as ICodeCellModel;
       expect(cAny.sharedModel.source).toBe('a=5\ntest=a+99\nb=a$Tag1+99');
@@ -559,7 +559,7 @@ describe('Identifier reference update', () => {
       dfmetadata.tag = "";
       notebook.cells.get(0).setMetadata('dfmetadata', dfmetadata);
 
-      await updateNotebookCellsWithTag(notebook as DataflowNotebookModel, refId, sessionContext)
+      await updateNotebookCellsWithTag("", notebook as DataflowNotebookModel, refId, sessionContext)
 
       let cAny = notebook?.cells.get(1) as ICodeCellModel;
       expect(cAny.outputs.length).toBe(1);

--- a/packages/dfnotebook/test/svg.d.ts
+++ b/packages/dfnotebook/test/svg.d.ts
@@ -1,0 +1,4 @@
+declare module '*.svg' {
+    const value: string;
+    export default value;
+}


### PR DESCRIPTION
1. Implementation of dynamic UUID/tag management for identifiers:
   - UUID/tag is added or removed based on the number of times an identifier is exported.
   - If an identifier is exported only once, no UUID/tag is added when referenced in code cells.
   - If an identifier is exported multiple times, a UUID/tag is added to the identifier.
   - When there is ambiguity between local and global variables, the UUID/tag value is retained even if the variable is exported only once.
   - If any exported identifier is deleted and references exist in code cells, a deleted cell UUID is added to the identifier.

2. Metadata updates:
   - Code cell metadata now includes a dfmetadata with the following structure:
     dfmetadata = { 
          tag: "",
          inputVars: { ref: {}, tag_refs: {} },
          outputVars: {},
          persistentCode: ""
      };

3. Toggle Tags Feature:
   - A "Tags" toggle switch has been added to the user interface.
   - This switch allows users to show or hide tags in dfpython3 notebooks only.
   - By default, the Tags toggle is in the selected state, showing tags when present.

4. Updated cell tagging functionality:
   - The "Tag cell" option has been removed.
   - Two new options have been added: "Add cell tag" and "Modify cell tag".
   - Add cell tag and Modify cell tag options are enabled only for code cells and disabled for markdown and raw cells. 
   
   4.1.  Add cell tag:
   - When a cell tag is added, the UUID of the tagged cell is replaced with the tag in the input prompt and in code cells where the UUID is referenced.
   - The Add cell tag dialog prevents adding duplicate tags.
   - The Add cell tag option is disabled when a cell tag already exists.
   
   4.2.  Modify cell tag:
   - Provides a new option "Update references", which is selected by default.
   - Allows users to delete a cell tag or rename it.
   - Modify cell tag option is disabled when there is no cell tag.
   
   4.3. Delete cell tag:
   - With "Update references" selected: Deletes the tag for a cell and replaces the tag with UUID in all places.
   - With "Update references" unchecked: Deletes the cell tag, but tag is not replaced with UUID in code cells.
   
   4.4. Rename cell tag:
   - With "Update references" selected: Replaces the old tag with the new tag value everywhere.
   - With "Update references" unchecked: Updates the tag value only in the input prompt, leaving the old tag value in the rest of the code.